### PR TITLE
whitelist: add timelock to LotToken

### DIFF
--- a/projects/bsc-library/contracts/BEP20.sol
+++ b/projects/bsc-library/contracts/BEP20.sol
@@ -211,6 +211,23 @@ contract BEP20 is Context, IBEP20, Ownable {
     }
 
     /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - When `from` and `to` are both non-zero, `amount` of tokens will be
+     *   transferred from `from` to `to`.
+     * - When `from` is zero, `amount` tokens will be minted for `to`.
+     * - When `to` is zero, `amount` tokens will be burned from `from`.
+     * - `from` and `to` are never both zero.
+     *
+     * This function can be overridden to implement custom transfer logic, such as
+     * transfer restrictions, whitelisting, anti-bot mechanisms, or fee enforcement.
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual {}
+
+    /**
      * @dev Moves tokens `amount` from `sender` to `recipient`.
      *
      * This is internal function is equivalent to {transfer}, and can be used to
@@ -231,6 +248,8 @@ contract BEP20 is Context, IBEP20, Ownable {
     ) internal {
         require(sender != address(0), "BEP20: transfer from the zero address");
         require(recipient != address(0), "BEP20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
 
         _balances[sender] = _balances[sender] - amount;
         _balances[recipient] = _balances[recipient] + amount;

--- a/projects/token-farm/contracts/LotToken.sol
+++ b/projects/token-farm/contracts/LotToken.sol
@@ -5,6 +5,7 @@ import "bsc-library/contracts/BEP20.sol";
 
 contract LotToken is BEP20("League of traders", "LOT") {
     uint256 public transferAllowedTimestamp;
+    bool public transferUpdated;
     uint256 public ETA;
     mapping(address => bool) public whitelist;
 
@@ -19,14 +20,16 @@ contract LotToken is BEP20("League of traders", "LOT") {
     }
 
     function setTransferAllowedTimestamp(uint256 newTimestamp) external onlyOwner {
-        if (transferAllowedTimestamp > block.timestamp && ETA == 0) {
+        if (block.timestamp < transferAllowedTimestamp && ETA == 0) {
             transferAllowedTimestamp = newTimestamp;
         } else {
+            require(!transferUpdated, "Already updated once");
             if (ETA == 0) {
                 ETA = transferAllowedTimestamp + 1 days;
             }
-            require(newTimestamp <= ETA, "Too late to update");
+            require(block.timestamp <= ETA, "Too late to update");
             transferAllowedTimestamp = newTimestamp;
+            transferUpdated = true;
         }
         emit NewTransferAllowedTimestamp(newTimestamp);
     }

--- a/projects/token-farm/contracts/LotToken.sol
+++ b/projects/token-farm/contracts/LotToken.sol
@@ -3,9 +3,52 @@ pragma solidity 0.8.26;
 
 import "bsc-library/contracts/BEP20.sol";
 
-// CakeToken with Governance.
 contract LotToken is BEP20("League of traders", "LOT") {
-    /// @dev Creates `_amount` token to `_to`. Must only be called by the owner.
+    uint256 public transferAllowedTimestamp;
+    uint256 public ETA;
+    mapping(address => bool) public whitelist;
+
+    event NewTransferAllowedTimestamp(uint256 newTimestamp);
+    event WhitelistAdded(address user);
+    event WhitelistRemoved(address user);
+
+    constructor(uint256 _transferAllowedTimestamp) {
+        require(_transferAllowedTimestamp >= block.timestamp, "Invalid launch time");
+        transferAllowedTimestamp = _transferAllowedTimestamp;
+        whitelist[msg.sender] = true;
+    }
+
+    function setTransferAllowedTimestamp(uint256 newTimestamp) external onlyOwner {
+        if (transferAllowedTimestamp > block.timestamp && ETA == 0) {
+            transferAllowedTimestamp = newTimestamp;
+        } else {
+            if (ETA == 0) {
+                ETA = transferAllowedTimestamp + 1 days;
+            }
+            require(newTimestamp <= ETA, "Too late to update");
+            transferAllowedTimestamp = newTimestamp;
+        }
+        emit NewTransferAllowedTimestamp(newTimestamp);
+    }
+
+    function addToWhitelist(address user) external onlyOwner {
+        whitelist[user] = true;
+        emit WhitelistAdded(user);
+    }
+
+    function removeFromWhitelist(address user) external onlyOwner {
+        whitelist[user] = false;
+        emit WhitelistRemoved(user);
+    }
+
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal override {
+        require(
+            block.timestamp >= transferAllowedTimestamp || whitelist[from] || whitelist[to],
+            "Transfers not allowed yet"
+        );
+        super._beforeTokenTransfer(from, to, amount);
+    }
+
     function mintTo(address _to, uint256 _amount) public onlyOwner {
         _mint(_to, _amount);
     }


### PR DESCRIPTION
### 📌 Summary
This PR introduces time-based transfer restrictions and a whitelist mechanism to the `LotToken` contract for enhanced control during the initial token launch phase.

---

### 🔧 Changes Introduced

- **Transfer Restriction Logic**
  - Transfers are disabled until `transferAllowedTimestamp`.
  - Exceptions are made for addresses in the `whitelist`.
  - `transferAllowedTimestamp` can be updated under specific conditions:
    - If current time is before the original timestamp and no ETA has been set, it can be updated freely.

- **Whitelist Functionality**
  - `addToWhitelist(address)` and `removeFromWhitelist(address)` allow the owner to manage privileged addresses.
  - Whitelisted addresses are allowed to transfer even before the global timestamp.

- **Minting Function**
  - `mintTo(address _to, uint256 _amount)` function enables the owner to mint tokens to any address.

- **Event Emissions**
  - Events are emitted on:
    - `NewTransferAllowedTimestamp(uint256)`
    - `WhitelistAdded(address)`
    - `WhitelistRemoved(address)`

---

### 📄 Rationale
These changes allow for:
- Controlled TGE and post-launch behavior
- Early distribution to strategic participants (e.g., partners, exchanges)
- Flexibility in managing token liquidity access

---

### 🔗 Related Commit
Commit hash with implemented changes:  
`91b1da32c6c379d5cfc481a3b81449ba4e5c8077`